### PR TITLE
Issue #130 : How get all comment of post?

### DIFF
--- a/InstagramAPI.py
+++ b/InstagramAPI.py
@@ -557,8 +557,8 @@ class InstagramAPI:
         })
         return self.SendRequest('media/'+ str(mediaId) +'/unlike/', self.generateSignature(data))
 
-    def getMediaComments(self, mediaId):
-        return self.SendRequest('media/'+ mediaId +'/comments/?')
+    def getMediaComments(self, mediaId, max_id=''):
+        return self.SendRequest('media/'+ mediaId +'/comments/?max_id='+max_id)
 
     def setNameAndPhone(self, name = '', phone = ''):
         data = json.dumps({

--- a/examples/get_all_comments.py
+++ b/examples/get_all_comments.py
@@ -1,0 +1,51 @@
+from InstagramAPI import InstagramAPI
+import time
+from datetime import datetime
+
+username = ''
+pwd      = ''
+media_id = '1477006830906870775_19343908'
+
+#stop conditions, the script will end when first of them will be true
+until_date = '2017-03-31'
+count      = 100
+
+
+API = InstagramAPI(username,pwd)
+API.login()
+
+has_more_comments = True
+max_id            = ''
+comments          = []
+
+while has_more_comments:
+    _ = API.getMediaComments(media_id,max_id=max_id)
+    #comments' page come from older to newer, lets preserve desc order in full list
+    for c in reversed(API.LastJson['comments']):
+        comments.append(c)
+    has_more_comments = API.LastJson.get('has_more_comments',False)
+    #evaluate stop conditions
+    if count and len(comments)>=count:
+        comments = comments[:count]
+        #stop loop
+        has_more_comments = False
+        print "stopped by count"
+    if until_date:
+        older_comment = comments[-1]
+        dt=datetime.utcfromtimestamp(older_comment.get('created_at_utc',0))
+        #only check all records if the last is older than stop condition
+        if dt.isoformat()<=until_date:
+            #keep comments after until_date
+            comments = [
+                c
+                for c in comments
+                if datetime.utcfromtimestamp(c.get('created_at_utc',0)) > until_date
+            ]
+            #stop loop
+            has_more_comments = False
+            print "stopped by until_date"
+    #next page
+    if has_more_comments:
+        max_id = API.LastJson.get('next_max_id','')
+        time.sleep(2)
+


### PR DESCRIPTION
Code to solve issue #130 
Example is added:
Execution of `examples/get_all_comments.py` with
```
#stop conditions, the script will end when first of them will be true
until_date = '2017-03-20'
count      = 100
``` 
```
stopped by count
>>> len(comments)
100
>>> datetime.utcfromtimestamp(comments[0].get('created_at_utc',0))
datetime.datetime(2017, 4, 5, 17, 23, 20)
>>> datetime.utcfromtimestamp(comments[-1].get('created_at_utc',0))
datetime.datetime(2017, 3, 26, 0, 45, 54)
>>> datetime.utcfromtimestamp(comments[4].get('created_at_utc',0))
datetime.datetime(2017, 3, 31, 18, 31, 44)
>>> datetime.utcfromtimestamp(comments[3].get('created_at_utc',0))
datetime.datetime(2017, 4, 1, 14, 13, 50)
>>> 

```

Execution with until_date condition
```
#stop conditions, the script will end when first of them will be true
until_date = '2017-03-31'
count      = 100
```
``` 
stopped by until_date
>>> len(comments)
5
>>> 
>>> datetime.utcfromtimestamp(comments[0].get('created_at_utc',0))
datetime.datetime(2017, 4, 5, 17, 23, 20)
>>> datetime.utcfromtimestamp(comments[-1].get('created_at_utc',0))
datetime.datetime(2017, 3, 31, 18, 31, 44)
>>> datetime.utcfromtimestamp(comments[-2].get('created_at_utc',0))
datetime.datetime(2017, 4, 1, 14, 13, 50)

```