### PR TITLE
changing name of InstagramAPI instance to avoid errors

### DIFF
--- a/test.py
+++ b/test.py
@@ -5,9 +5,9 @@
 
 from InstagramAPI import InstagramAPI
 
-InstagramAPI = InstagramAPI("login", "password")
-InstagramAPI.login() # login
-InstagramAPI.tagFeed("cat") # get media list by tag #cat
-media_id = InstagramAPI.LastJson # last response JSON
-InstagramAPI.like(media_id["ranked_items"][0]["pk"]) # like first media
-InstagramAPI.getUserFollowers(media_id["ranked_items"][0]["user"]["pk"]) # get first media owner followers
+api = InstagramAPI("login", "password")
+api.login() # login
+api.tagFeed("cat") # get media list by tag #cat
+media_id = api.LastJson # last response JSON
+api.like(media_id["ranked_items"][0]["pk"]) # like first media
+api.getUserFollowers(media_id["ranked_items"][0]["user"]["pk"]) # get first media owner followers


### PR DESCRIPTION
`InstagramAPI = InstagramAPI("login", "password")` - after assigning InstagramAPI to InstagramAPI I encountered errors while calling InstagramAPI instance. With changing name of instance to something else it was no mistakes. Not shure if it just me, but I think this commit can save some time to many people :)