### PR TITLE
extend() over append() for better perf when dealing with larger sets of data

### DIFF
--- a/InstagramAPI/__init__.py
+++ b/InstagramAPI/__init__.py
@@ -939,8 +939,8 @@ class InstagramAPI:
             self.getUserFollowers(usernameId,next_max_id)
             temp = self.LastJson
 
-            for item in temp["users"]:
-                followers.append(item)
+            if temp["users"]:
+                followers.extend(temp["users"])
 
             if temp["big_list"] == False:
                 return followers            
@@ -953,8 +953,8 @@ class InstagramAPI:
             self.getUserFollowings(usernameId,next_max_id)
             temp = self.LastJson
 
-            for item in temp["users"]:
-                followers.append(item)
+            if temp["users"]:
+                followers.extend(temp["users"])
 
             if temp["big_list"] == False:
                 return followers            
@@ -966,8 +966,8 @@ class InstagramAPI:
         while 1:
             self.getUserFeed(usernameId, next_max_id, minTimestamp)
             temp = self.LastJson
-            for item in temp["items"]:
-                user_feed.append(item)
+            if temp["items"]:
+                user_feed.extend(temp["items"])
             if temp["more_available"] == False:
                 return user_feed
             next_max_id = temp["next_max_id"]
@@ -989,8 +989,8 @@ class InstagramAPI:
             temp = self.LastJson
             try:
                 next_id = temp["next_max_id"]
-                for item in temp["items"]:
-                    liked_items.append(item)
+                if temp["items"]:
+                    liked_items.extend(temp["items"])
             except KeyError as e:
                 break
         return liked_items


### PR DESCRIPTION
Extend performs a bit better over larger lists and is generally negligible against append on smaller ones. Below is the code of a very rough performance test to show proof.

Source:
``` 
import timeit

def test_extend():
    data = []
    thing = range(5000)
    data.extend(thing)

def test_append():
    data = []
    thing = range(5000)
    for t in thing:
        data.append(t)

print(timeit.timeit('test_extend()', setup='from __main__ import test_extend', number=1000))
print(timeit.timeit('test_append()', setup='from __main__ import test_append', number=1000))
```

Output:
```
0.0559940338135
0.424235105515
```

Thanks for working on this. Looking forward to potentially helping out more in the future!