### PR TITLE
JSON key for changing profile name is wrong

### DIFF
--- a/InstagramAPI/InstagramAPI.py
+++ b/InstagramAPI/InstagramAPI.py
@@ -638,7 +638,7 @@ class InstagramAPI:
                            'external_url': url,
                            'phone_number': phone,
                            'username': self.username,
-                           'full_name': first_name,
+                           'first_name': first_name,
                            'biography': biography,
                            'email': email,
                            'gender': gender})


### PR DESCRIPTION
Changing profile name with this key is not working. I have changed the key from 'full_name' to 'first_name'.