### PR TITLE
Updated setup.py so moviepy doesnt conflict with other packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     install_requires=[
         "requests==2.11.1",
         "requests-toolbelt==0.7.0",
-        "moviepy==0.2.3.2"
+        "moviepy>=0.2.3.2"
     ])


### PR DESCRIPTION
InstagramAPI requires `moviepy==0.2.3.2` which requires `decorator==4.0.11` and conflicts with a lot of up-to-date libraries, such as NetworkX.

However, `moviepy==0.2.3.5` requires `decorator>=4.0.3,<5.0` which shouldn't conflict with anything.

Instead of having a hard requirement on `moviepy`, require version `0.2.3.2` or higher should resolve conflicts.

Fixes #435  