### PR TITLE
Close handle on video file after being configured

### DIFF
--- a/InstagramAPI/InstagramAPI.py
+++ b/InstagramAPI/InstagramAPI.py
@@ -527,6 +527,7 @@ class InstagramAPI:
             '_uid': self.username_id,
             'caption': caption,
         })
+        clip.close()
         return self.SendRequest('media/configure/?video=1', self.generateSignature(data))
 
     def configure(self, upload_id, photo, caption=''):


### PR DESCRIPTION
This prevents the file being locked after the method call has completed so that the user can delete the file if needed