### PR TITLE
[Security] Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.11.1
+requests==2.20.0
 requests-toolbelt==0.7.0
 moviepy==0.2.2.11


### PR DESCRIPTION
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
Source: https://nvd.nist.gov/vuln/detail/CVE-2018-18074